### PR TITLE
Print usage without arguments + add default font path/file extension

### DIFF
--- a/tdfiglet.c
+++ b/tdfiglet.c
@@ -117,6 +117,10 @@ main(int argc, char *argv[])
 	opt.info = false;
 	opt.encoding = ENC_UNICODE;
 
+	if (argc == 1) {
+		usage();
+	}
+
 	while((o = getopt(argc, argv, "w:j:c:e:i")) != -1) {
 		switch (o) {
 			case 'w':

--- a/tdfiglet.c
+++ b/tdfiglet.c
@@ -40,6 +40,14 @@
 #define ENC_UNICODE	0
 #define ENC_ANSI	1
 
+#ifndef FONT_DIR
+#define FONT_DIR	"fonts"
+#endif /* FONT_DIR */
+
+#ifndef FONT_EXT
+#define FONT_EXT	"tdf"
+#endif /* FONT_EXT */
+
 typedef struct opt_s {
 	uint8_t justify;
 	uint8_t width;
@@ -198,7 +206,7 @@ main(int argc, char *argv[])
 }
 
 font_t
-*loadfont(char *fn) {
+*loadfont(char *fn_arg) {
 
 	font_t *font;
 	uint8_t *map = NULL;
@@ -206,8 +214,19 @@ font_t
 	struct stat st;
 	size_t len;
 	uint8_t *p;
+	char *fn = strdup("");
 
 	const char *magic = "\x13TheDraw FONTS file\x1a";
+
+	if (!strchr(fn_arg, '/')) {
+		if (strchr(fn_arg, '.')) {
+			sprintf(fn, "%s/%s", FONT_DIR, fn_arg);
+		} else {
+			sprintf(fn, "%s/%s.%s", FONT_DIR, fn_arg, FONT_EXT);
+		}
+	} else {
+		strcpy(fn, fn_arg);
+	}
 
 	fd = open(fn, O_RDONLY);
 
@@ -303,6 +322,7 @@ font_t
 		}
 	}
 
+	free(fn);
 	return font;
 }
 


### PR DESCRIPTION
- Don't crash if we're run without arguments
- Automatically prepend a default FONT_DIR to the font file name, if missing
- Automatically append '.tdf' to the font file, if missing